### PR TITLE
feat: enable merge-base comparison between working tree and specific ref

### DIFF
--- a/lua/reviewthem/commands/review.lua
+++ b/lua/reviewthem/commands/review.lua
@@ -45,7 +45,7 @@ M.start = function(base_ref, compare_ref)
     if (base_ref == nil or base_ref == "") and (compare_ref == nil or compare_ref == "") then
       msg = "Review session started: HEAD...Working Directory"
     elseif compare_ref == nil or compare_ref == "" then
-      msg = string.format("Review session started: %s..Working Directory", base_ref)
+      msg = string.format("Review session started: %s...Working Directory", base_ref)
     else
       msg = string.format("Review session started: %s...%s", base_ref, compare_ref)
     end

--- a/lua/reviewthem/diff/alt-diffview.lua
+++ b/lua/reviewthem/diff/alt-diffview.lua
@@ -22,8 +22,8 @@ M.start = function(base_ref, compare_ref)
       -- alt-diffview shows untracked files when no refs are specified
       cmd = "AltDiffviewOpen"
     else
-      -- Compare against a specific ref
-      cmd = string.format("AltDiffviewOpen %s", base_ref)
+      -- Use --merge-base option to show changes from merge base
+      cmd = string.format("AltDiffviewOpen %s --merge-base", base_ref)
     end
   else
     -- Normal comparison

--- a/lua/reviewthem/diff/diffview.lua
+++ b/lua/reviewthem/diff/diffview.lua
@@ -19,6 +19,8 @@ M.start = function(base_ref, compare_ref)
       cmd = "DiffviewOpen"
     else
       cmd = string.format("DiffviewOpen %s", base_ref)
+      -- Show warning about diffview limitation
+      vim.notify("reviewthem.nvim: Due to diffview limitations, showing two-dot diff instead of three-dot diff", vim.log.levels.WARN)
     end
   else
     -- Normal comparison

--- a/lua/reviewthem/git.lua
+++ b/lua/reviewthem/git.lua
@@ -11,7 +11,12 @@ M.get_diff_files = function(base_ref, compare_ref)
       -- No base ref means compare index with working directory
       cmd = "git diff --name-status"
     else
-      cmd = string.format("git diff --name-status %s", base_ref)
+      local merge_base = M.get_merge_base(base_ref)
+      if merge_base then
+        cmd = string.format("git diff --name-status %s", merge_base)
+      else
+        cmd = string.format("git diff --name-status %s", base_ref)
+      end
     end
     local result = vim.fn.systemlist(cmd)
 
@@ -126,4 +131,15 @@ M.get_relative_path = function(absolute_path)
   return relative
 end
 
+-- Get merge base between HEAD and the given ref
+M.get_merge_base = function(ref)
+  local cmd = string.format("git merge-base HEAD %s", vim.fn.shellescape(ref))
+  local result = vim.fn.system(cmd)
+  if vim.v.shell_error == 0 and result ~= "" then
+    return vim.trim(result)
+  end
+  return nil
+end
+
 return M
+


### PR DESCRIPTION
## Summary

Enable three-dot diff (merge-base comparison) when comparing working tree against a specific ref

## Changes

- Add `get_merge_base()` function to find the common ancestor between HEAD and a reference
- Update `get_diff_files()` to use merge base when comparing working tree against a ref
- Configure alt-diffview to use `--merge-base` option for accurate comparison
- Add warning for diffview.nvim users about two-dot diff limitation
- Fix typo in review start message (double dots to triple dots)

## Motivation

When reviewing changes against a base branch (e.g., `main`), users typically want to see only the changes introduced in their current branch, not all differences between branches. This PR implements three-dot diff behavior (`base...HEAD`) instead of two-dot diff (`base..HEAD`) when comparing the working tree against a reference.

## Technical Details

- For alt-diffview users: Utilizes the `--merge-base` option for accurate three-dot comparison
- For diffview.nvim users: Shows a warning since it doesn't support merge-base comparison
- The merge base calculation only applies when comparing working tree against a ref (not for ref-to-ref comparisons)

## Testing

- [x] Tested with alt-diffview: correctly shows only branch changes
- [x] Tested with diffview.nvim: warning displayed, falls back to two-dot diff
- [x] Verified merge base calculation works correctly
- [x] Existing ref-to-ref comparisons remain unchanged
