### PR TITLE
feat: improve git ref completion with prefix filtering and remote branches

### DIFF
--- a/lua/reviewthem/commands.lua
+++ b/lua/reviewthem/commands.lua
@@ -87,16 +87,22 @@ register_idle_commands = function()
     vim.notify(string.format("Review session '%s' started (%d files)", session.name, #session.diff_files), vim.log.levels.INFO)
   end, {
     nargs = "*",
-    complete = function(_, cmdline)
+    complete = function(arg_lead, cmdline)
       local args = vim.split(cmdline, "%s+", { trimempty = true })
       local n = #args
       if cmdline:match("%s$") then
         n = n + 1
       end
-      if n <= 3 then
-        return git.get_refs()
+      if n > 3 then
+        return {}
       end
-      return {}
+      local matches = {}
+      for _, ref in ipairs(git.get_refs()) do
+        if ref:find(arg_lead, 1, true) == 1 then
+          table.insert(matches, ref)
+        end
+      end
+      return matches
     end,
     desc = "Start a new review session",
   })

--- a/lua/reviewthem/git/init.lua
+++ b/lua/reviewthem/git/init.lua
@@ -163,8 +163,8 @@ end
 ---@return string[]
 M.get_refs = function()
   local refs = {}
-  -- Branches
-  local branches = vim.fn.systemlist("git branch --format='%(refname:short)'")
+  -- Branches (including remote-tracking)
+  local branches = vim.fn.systemlist("git branch -a --format='%(refname:short)'")
   for _, b in ipairs(branches) do
     if b ~= "" then
       table.insert(refs, b)


### PR DESCRIPTION
## Summary
- Include remote-tracking branches (`git branch -a`) in completion candidates so users can tab-complete refs like `origin/main`
- Filter completion results by the typed prefix (`arg_lead`) for more responsive and accurate completions

## Test plan
- [ ] Open Neovim and type `:ReviewThemStart <Tab>` — verify both local and remote branches appear
- [ ] Type `:ReviewThemStart ori<Tab>` — verify only refs starting with `ori` are shown
- [ ] Type `:ReviewThemStart base compare <Tab>` — verify no completions appear (max 2 positional args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)