### PR TITLE
Fix diff pane position with splitright enabled

### DIFF
--- a/lua/reviewthem/ui/init.lua
+++ b/lua/reviewthem/ui/init.lua
@@ -70,10 +70,11 @@ M.open = function(session)
   end)
 
   -- 2. orig_winnr is still valid — split it for old/new panes.
-  --    :vsplit puts the new window on the left, so it becomes the "old"
-  --    pane and orig_winnr (right) becomes the "new" pane.
+  --    :leftabove vsplit always puts the new window on the left regardless
+  --    of 'splitright', so it becomes the "old" pane and orig_winnr (right)
+  --    becomes the "new" pane.
   vim.api.nvim_set_current_win(orig_winnr)
-  vim.cmd("vsplit")
+  vim.cmd("leftabove vsplit")
   local old_winnr = vim.api.nvim_get_current_win()
   local new_winnr = orig_winnr
 

--- a/lua/reviewthem/ui/init.lua
+++ b/lua/reviewthem/ui/init.lua
@@ -55,7 +55,7 @@ M.open = function(session)
 
   suspend_nvimtree()
 
-  -- Save the current window — this will become the "old" diff pane
+  -- Save the current window — this will become the "new" diff pane
   local orig_winnr = vim.api.nvim_get_current_win()
 
   -- 1. Open file tree sidebar (creates vsplit to the left)
@@ -69,11 +69,13 @@ M.open = function(session)
     file_tree.refresh(session)
   end)
 
-  -- 2. orig_winnr is still valid — split it for old/new panes
+  -- 2. orig_winnr is still valid — split it for old/new panes.
+  --    :vsplit puts the new window on the left, so it becomes the "old"
+  --    pane and orig_winnr (right) becomes the "new" pane.
   vim.api.nvim_set_current_win(orig_winnr)
   vim.cmd("vsplit")
-  local new_winnr = vim.api.nvim_get_current_win()
-  local old_winnr = orig_winnr
+  local old_winnr = vim.api.nvim_get_current_win()
+  local new_winnr = orig_winnr
 
   -- 3. Render first file
   diff_view.open(session, old_winnr, new_winnr)


### PR DESCRIPTION
## Summary
- Use `leftabove vsplit` instead of bare `vsplit` when creating the old/new diff panes
- Ensures old (base) is always on the left and new (compare) on the right, regardless of the user's `splitright` setting
- Without this fix, users with `set splitright` would see the panes swapped

## Test plan
- [ ] Open a review session with `set splitright` enabled — old pane should be on the left
- [ ] Open a review session with `set nosplitright` — same layout, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)