### PR TITLE
Fix file tree scroll sync with diff panes

### DIFF
--- a/lua/reviewthem/ui/file_tree.lua
+++ b/lua/reviewthem/ui/file_tree.lua
@@ -248,6 +248,8 @@ M.open = function(session, on_select, on_toggle_reviewed)
   vim.wo[winnr].cursorline = true
   vim.wo[winnr].foldcolumn = "0"
   vim.wo[winnr].spell = false
+  vim.wo[winnr].scrollbind = false
+  vim.wo[winnr].cursorbind = false
 
   -- Only show cursorline in focused window
   vim.api.nvim_create_autocmd("WinEnter", {


### PR DESCRIPTION
## Summary
- Disable `scrollbind` and `cursorbind` on the file tree window to prevent it from scrolling in sync with the diff panes
- The file tree was inheriting these options when switching from a diff pane, causing unintended scroll behavior

## Test plan
- [ ] Open a review session with multiple files
- [ ] Scroll through the diff panes and confirm the file tree stays in place
- [ ] Navigate the file tree independently and confirm it scrolls on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)