### PR TITLE
fix: prevent WinEnter/WinLeave autocmd accumulation on file switch

### DIFF
--- a/lua/reviewthem/diff/split.lua
+++ b/lua/reviewthem/diff/split.lua
@@ -260,22 +260,27 @@ M.render_file = function(session, file, old_winnr, new_winnr)
 
     -- Only show cursorline in focused window
     local bufnr = vim.api.nvim_win_get_buf(winnr)
-    vim.api.nvim_create_autocmd("WinEnter", {
-      buffer = bufnr,
-      callback = function()
-        if vim.api.nvim_win_is_valid(winnr) then
-          vim.wo[winnr].cursorline = true
-        end
-      end,
-    })
-    vim.api.nvim_create_autocmd("WinLeave", {
-      buffer = bufnr,
-      callback = function()
-        if vim.api.nvim_win_is_valid(winnr) then
-          vim.wo[winnr].cursorline = false
-        end
-      end,
-    })
+    if not vim.b[bufnr].reviewthem_cursorline_set then
+      vim.b[bufnr].reviewthem_cursorline_set = true
+      vim.api.nvim_create_autocmd("WinEnter", {
+        buffer = bufnr,
+        callback = function()
+          local win = vim.api.nvim_get_current_win()
+          if vim.api.nvim_win_is_valid(win) then
+            vim.wo[win].cursorline = true
+          end
+        end,
+      })
+      vim.api.nvim_create_autocmd("WinLeave", {
+        buffer = bufnr,
+        callback = function()
+          local win = vim.api.nvim_get_current_win()
+          if vim.api.nvim_win_is_valid(win) then
+            vim.wo[win].cursorline = false
+          end
+        end,
+      })
+    end
   end
 
   -- Apply decorations


### PR DESCRIPTION
## Summary
- WinEnter/WinLeave autocmds for cursorline management were created on every `render_file()` call without deduplication
- Since diff buffers are reused, switching files caused autocmds to pile up indefinitely
- Added a buffer variable guard to create autocmds only once per buffer
- Changed callbacks to dynamically look up the current window instead of capturing potentially stale `winnr`