### PR TITLE
fix: seed math.random to prevent ID collisions across sessions

### DIFF
--- a/plugin/reviewthem.lua
+++ b/plugin/reviewthem.lua
@@ -6,4 +6,5 @@ end
 if vim.g.loaded_reviewthem == 1 then
   return
 end
+math.randomseed(os.clock() * 1000 + vim.uv.hrtime() % 1000000)
 vim.g.loaded_reviewthem = 1


### PR DESCRIPTION
## Summary
- `math.random` was never seeded, causing LuaJIT to produce the same random sequence on every Neovim startup
- This could lead to duplicate comment/session IDs across sessions
- Seeds with `os.clock()` and `vim.uv.hrtime()` for sufficient entropy