### PR TITLE
fix: correct end_line calculation for visual range comments

### DIFF
--- a/lua/reviewthem/commands.lua
+++ b/lua/reviewthem/commands.lua
@@ -258,7 +258,10 @@ register_session_commands = function()
     local start_line = context.lineno
     local end_line = context.lineno
     if cmd.range == 2 then
-      end_line = start_line + (cmd.line2 - cmd.line1)
+      local end_context = ui_mod.get_line_context(vim.api.nvim_get_current_buf(), cmd.line2)
+      if end_context and end_context.side == context.side then
+        end_line = end_context.lineno
+      end
     end
 
     local prefix = context.hunk_line.type == "add" and "+" or

--- a/lua/reviewthem/diff/init.lua
+++ b/lua/reviewthem/diff/init.lua
@@ -31,6 +31,14 @@ M.get_cursor_context = function()
   return split.get_cursor_context()
 end
 
+--- Get context for a specific buffer row.
+---@param bufnr number
+---@param row number 1-based row
+---@return table|nil
+M.get_line_context = function(bufnr, row)
+  return split.get_line_context(bufnr, row)
+end
+
 --- Show a specific file.
 ---@param session ReviewSession
 ---@param file DiffFile

--- a/lua/reviewthem/diff/split.lua
+++ b/lua/reviewthem/diff/split.lua
@@ -333,6 +333,33 @@ M.get_cursor_context = function()
   }
 end
 
+--- Get context for a specific buffer row (without moving the cursor).
+---@param bufnr number
+---@param row number 1-based row
+---@return table|nil
+M.get_line_context = function(bufnr, row)
+  local line_map
+  if bufnr == view_state.old_bufnr then
+    line_map = view_state.line_map_old
+  elseif bufnr == view_state.new_bufnr then
+    line_map = view_state.line_map_new
+  else
+    return nil
+  end
+
+  local entry = line_map[row]
+  if not entry or entry.type ~= "diff_line" then
+    return nil
+  end
+
+  return {
+    file = entry.file,
+    side = entry.side,
+    lineno = entry.lineno,
+    hunk_line = entry.hunk_line,
+  }
+end
+
 --- Get the current file being viewed.
 ---@return string|nil
 M.get_current_file = function()

--- a/lua/reviewthem/ui/init.lua
+++ b/lua/reviewthem/ui/init.lua
@@ -160,6 +160,14 @@ M.get_cursor_context = function()
   return diff_view.get_cursor_context()
 end
 
+--- Get context for a specific buffer row.
+---@param bufnr number
+---@param row number 1-based row
+---@return table|nil
+M.get_line_context = function(bufnr, row)
+  return diff_view.get_line_context(bufnr, row)
+end
+
 --- Check if the UI is open.
 ---@return boolean
 M.is_open = function()


### PR DESCRIPTION
## Summary
- Range comment `end_line` was calculated as `start_line + (cmd.line2 - cmd.line1)`, mapping buffer line spans to source line spans
- This was incorrect because the diff buffer contains padding lines, hunk headers, and file headers that don't map 1:1 to source lines
- Added `get_line_context(bufnr, row)` to look up the actual source line number for any buffer row
- The range handler now uses this to get the correct end line number