### PR TITLE
fix: add nil checks for active session in commands to prevent crashes

### DIFF
--- a/lua/reviewthem/commands.lua
+++ b/lua/reviewthem/commands.lua
@@ -247,6 +247,7 @@ register_session_commands = function()
   vim.api.nvim_create_user_command("ReviewThemAddComment", function(cmd)
     local state = require("reviewthem.session.state")
     local session = state.get_active()
+    if not session then return end
     local ui_mod = require("reviewthem.ui")
     local context = ui_mod.get_cursor_context()
 
@@ -376,6 +377,7 @@ register_session_commands = function()
   vim.api.nvim_create_user_command("ReviewThemShowComments", function()
     local state = require("reviewthem.session.state")
     local session = state.get_active()
+    if not session then return end
     local ui_mod = require("reviewthem.ui")
 
     local comments = session.comments
@@ -460,6 +462,7 @@ register_session_commands = function()
     else
       local state = require("reviewthem.session.state")
       local session = state.get_active()
+      if not session then return end
       local ui_mod = require("reviewthem.ui")
       file_tree.open(session, function(file_path)
         ui_mod.jump_to_file(file_path)


### PR DESCRIPTION
## Summary
- `ReviewThemAddComment`, `ReviewThemShowComments`, and `ReviewThemTree` accessed `session.comments` or `session.diff_files` without checking if `session` was nil
- While session commands are only registered during active sessions, edge cases (race conditions, interrupted close) could leave commands registered with no active session
- Added early-return nil guards to prevent crashes