### PR TITLE
fix: allow Esc to switch to normal mode in comment input

### DIFF
--- a/lua/reviewthem/ui/comment_input.lua
+++ b/lua/reviewthem/ui/comment_input.lua
@@ -156,8 +156,9 @@ M.open = function(opts)
   -- Keymaps
   for _, mode in ipairs({ "i", "n" }) do
     vim.keymap.set(mode, confirm_key, confirm, { buffer = bufnr, nowait = true, silent = true })
-    vim.keymap.set(mode, cancel_key, cancel, { buffer = bufnr, nowait = true, silent = true })
   end
+  vim.keymap.set("n", cancel_key, cancel, { buffer = bufnr, nowait = true, silent = true })
+  vim.keymap.set("n", "q", cancel, { buffer = bufnr, nowait = true, silent = true })
 
   -- Move cursor to input and start insert
   vim.api.nvim_win_set_cursor(winnr, { input_start_line, 0 })


### PR DESCRIPTION
## Summary
- `<Esc>` was mapped as cancel in both insert and normal mode in the comment input float
- This prevented users from switching to normal mode to edit multi-line comments
- Now `<Esc>` only cancels in normal mode; in insert mode it behaves normally (switches to normal mode)
- Added `q` as an additional normal-mode cancel key for consistency