### PR TITLE
feat: display review comments inline in the diff view

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is inspired by [ReviewIt](https://github.com/yoshiko-pg/reviewit) -
 - **Split diff view** — Side-by-side old/new comparison with syntax highlighting
 - **File tree sidebar** — Browse changed files, track review progress
 - **Line-level comments** — Floating input window, supports multi-line ranges
+- **Inline comment display** — Comments are rendered as virtual text blocks right below the commented lines
 - **Session management** — Named sessions persisted as JSON, pause and resume anytime
 - **Markdown export** — Copy review output to clipboard, ready for coding agents
 - **Context-aware commands** — Only relevant commands are available at each stage
@@ -140,6 +141,7 @@ All options are optional — defaults are shown below:
 ```lua
 require("reviewthem").setup({
   comment_sign = "💬",        -- sign shown on commented lines
+  inline_comments = true,     -- show comment text inline below commented lines
   file_tree_width = 30,       -- sidebar width in columns
   auto_save = true,           -- auto-save session on changes
   keymaps = {

--- a/doc/reviewthem.txt
+++ b/doc/reviewthem.txt
@@ -70,6 +70,7 @@ Call the setup function with optional configuration: >lua
 
     require("reviewthem").setup({
       comment_sign = "💬",
+      inline_comments = true,
       file_tree_width = 30,
       auto_save = true,
       keymaps = {
@@ -185,6 +186,12 @@ In the file tree sidebar:
 comment_sign~
     Default: "💬"
     Sign displayed at the end of commented lines in the diff view.
+
+inline_comments~
+    Default: true
+    Render the full comment text inline below the commented line in the
+    diff view using virtual lines. Set to false to only show the
+    |comment_sign| indicator.
 
 file_tree_width~
     Default: 30

--- a/lua/reviewthem/config.lua
+++ b/lua/reviewthem/config.lua
@@ -2,6 +2,7 @@ local M = {}
 
 M.defaults = {
   comment_sign = "💬",
+  inline_comments = true,
   file_tree_width = 30,
   auto_save = true,
   keymaps = {

--- a/lua/reviewthem/diff/renderer.lua
+++ b/lua/reviewthem/diff/renderer.lua
@@ -14,6 +14,8 @@ M.setup_highlights = function()
     ReviewThemLineNrNew = { default = true, fg = "#60e060" },
     ReviewThemLineNrContext = { default = true, link = "LineNr" },
     ReviewThemCommentSign = { default = true, fg = "#f0c060" },
+    ReviewThemInlineComment = { default = true, link = "Comment" },
+    ReviewThemInlineCommentBorder = { default = true, link = "NonText" },
     ReviewThemSeparator = { default = true, fg = "#555555" },
     ReviewThemPadding = { default = true, bg = "#1a1a2a" },
   }
@@ -79,6 +81,72 @@ M.add_comment_sign = function(bufnr, line_idx, sign)
   vim.api.nvim_buf_set_extmark(bufnr, ns, line_idx, 0, {
     virt_text = { { " " .. sign, "ReviewThemCommentSign" } },
     virt_text_pos = "eol",
+    priority = 20,
+  })
+end
+
+--- Wrap a single line of text by display width, safe for multibyte text.
+---@param line string
+---@param max_width number
+---@return string[]
+local function wrap_line(line, max_width)
+  if max_width < 1 then
+    max_width = 1
+  end
+  if line == "" or vim.fn.strdisplaywidth(line) <= max_width then
+    return { line }
+  end
+
+  local wrapped = {}
+  local current = ""
+  local current_width = 0
+  -- Iterate over UTF-8 characters
+  for ch in line:gmatch("[\1-\127\194-\244][\128-\191]*") do
+    local w = vim.fn.strdisplaywidth(ch)
+    if current_width + w > max_width and current ~= "" then
+      table.insert(wrapped, current)
+      current = ""
+      current_width = 0
+    end
+    current = current .. ch
+    current_width = current_width + w
+  end
+  if current ~= "" then
+    table.insert(wrapped, current)
+  end
+  return wrapped
+end
+
+--- Render comment blocks inline below a buffer line using virt_lines.
+--- Multiple comments are stacked in order.
+---@param bufnr number
+---@param line_idx number  0-indexed anchor line
+---@param comments Comment[]
+---@param sign string
+---@param max_width number  maximum display width for comment text lines
+M.add_inline_comments = function(bufnr, line_idx, comments, sign, max_width)
+  local virt_lines = {}
+  for _, comment in ipairs(comments) do
+    local range = comment.start_line == comment.end_line and ("L" .. comment.start_line)
+      or ("L" .. comment.start_line .. "-" .. comment.end_line)
+    table.insert(virt_lines, {
+      { "  ┌─ ", "ReviewThemInlineCommentBorder" },
+      { sign .. " " .. range, "ReviewThemInlineComment" },
+      { " ─", "ReviewThemInlineCommentBorder" },
+    })
+    for _, text_line in ipairs(vim.split(comment.text, "\n", { plain = true })) do
+      for _, chunk in ipairs(wrap_line(text_line, max_width)) do
+        table.insert(virt_lines, {
+          { "  │ ", "ReviewThemInlineCommentBorder" },
+          { chunk, "ReviewThemInlineComment" },
+        })
+      end
+    end
+    table.insert(virt_lines, { { "  └─", "ReviewThemInlineCommentBorder" } })
+  end
+
+  vim.api.nvim_buf_set_extmark(bufnr, ns, line_idx, 0, {
+    virt_lines = virt_lines,
     priority = 20,
   })
 end

--- a/lua/reviewthem/diff/split.lua
+++ b/lua/reviewthem/diff/split.lua
@@ -131,14 +131,34 @@ end
 local function apply_split_decorations(bufnr, line_map, session)
   renderer.clear(bufnr)
 
+  local config = require("reviewthem.config").get()
+
   local comment_lookup = {}
+  local inline_lookup = {}
   for _, c in ipairs(session.comments) do
     for l = c.start_line, c.end_line do
       comment_lookup[c.file .. ":" .. c.side .. ":" .. l] = true
     end
+    if config.inline_comments then
+      local key = c.file .. ":" .. c.side .. ":" .. c.end_line
+      inline_lookup[key] = inline_lookup[key] or {}
+      table.insert(inline_lookup[key], c)
+    end
+  end
+  for _, list in pairs(inline_lookup) do
+    table.sort(list, function(a, b)
+      if a.start_line ~= b.start_line then
+        return a.start_line < b.start_line
+      end
+      return tostring(a.id) < tostring(b.id)
+    end)
   end
 
-  local config = require("reviewthem.config").get()
+  -- Wrap width for inline comment text: keep blocks readable without
+  -- overflowing the window.
+  local winnr = vim.fn.bufwinid(bufnr)
+  local win_width = winnr ~= -1 and vim.api.nvim_win_get_width(winnr) or vim.o.columns
+  local wrap_width = math.max(20, math.min(80, win_width - 10))
 
   for i, entry in ipairs(line_map) do
     local line_idx = i - 1
@@ -151,6 +171,10 @@ local function apply_split_decorations(bufnr, line_map, session)
       local key = entry.file .. ":" .. entry.side .. ":" .. entry.lineno
       if comment_lookup[key] then
         renderer.add_comment_sign(bufnr, line_idx, config.comment_sign)
+      end
+      local inline_comments = inline_lookup[key]
+      if inline_comments then
+        renderer.add_inline_comments(bufnr, line_idx, inline_comments, config.comment_sign, wrap_width)
       end
     elseif entry.type == "padding" then
       vim.api.nvim_buf_set_extmark(bufnr, renderer.get_namespace(), line_idx, 0, {

--- a/tests/inline_comments_spec.lua
+++ b/tests/inline_comments_spec.lua
@@ -1,0 +1,144 @@
+-- Headless functional check for inline comment rendering via virt_lines.
+-- Run with: nvim --headless -l tests/inline_comments_spec.lua
+
+local script = debug.getinfo(1, "S").source:sub(2)
+local root = vim.fn.fnamemodify(script, ":h:h")
+vim.opt.rtp:prepend(root)
+
+require("reviewthem").setup()
+
+local renderer = require("reviewthem.diff.renderer")
+local split = require("reviewthem.diff.split")
+
+local failures = 0
+local function check(cond, msg)
+  if cond then
+    print("ok - " .. msg)
+  else
+    failures = failures + 1
+    print("FAIL - " .. msg)
+  end
+end
+
+---@type DiffFile
+local file = {
+  path = "test.lua",
+  status = "M",
+  hunks = {
+    {
+      header = "@@ -1,3 +1,3 @@",
+      old_start = 1,
+      old_count = 3,
+      new_start = 1,
+      new_count = 3,
+      lines = {
+        { type = "context", content = "line one", old_lineno = 1, new_lineno = 1 },
+        { type = "remove", content = "old line", old_lineno = 2 },
+        { type = "add", content = "new line", new_lineno = 2 },
+        { type = "context", content = "line three", old_lineno = 3, new_lineno = 3 },
+      },
+    },
+  },
+}
+
+local session = {
+  comments = {
+    {
+      id = "1",
+      file = "test.lua",
+      side = "new",
+      start_line = 2,
+      end_line = 2,
+      text = "Fix this\nplease",
+      created_at = 0,
+      updated_at = 0,
+    },
+    {
+      id = "2",
+      file = "test.lua",
+      side = "new",
+      start_line = 1,
+      end_line = 2,
+      text = "これは日本語の長いコメントです。マルチバイト文字が表示幅で正しく折り返されることを確認します。"
+        .. "さらに長くしてラップを強制します。",
+      created_at = 0,
+      updated_at = 0,
+    },
+  },
+}
+
+-- Two windows for old/new panes
+vim.cmd("vsplit")
+local wins = vim.api.nvim_tabpage_list_wins(0)
+split.render_file(session, file, wins[1], wins[2])
+
+local new_bufnr = vim.fn.bufnr("reviewthem://new")
+check(new_bufnr ~= -1, "new diff buffer exists")
+
+local extmarks = vim.api.nvim_buf_get_extmarks(new_bufnr, renderer.get_namespace(), 0, -1, { details = true })
+
+local virt_lines_marks = {}
+for _, mark in ipairs(extmarks) do
+  if mark[4].virt_lines then
+    table.insert(virt_lines_marks, mark)
+  end
+end
+
+check(#virt_lines_marks == 1, "exactly one virt_lines extmark on the new buffer (both comments share the anchor)")
+
+local mark = virt_lines_marks[1]
+-- Buffer layout: row 0 file header, row 1 hunk header, row 2 context L1, row 3 add L2
+check(mark and mark[2] == 3, "virt_lines anchored at the buffer row of new line 2")
+
+local lines = {}
+local max_text_width = 0
+for _, vline in ipairs(mark and mark[4].virt_lines or {}) do
+  local text = ""
+  for _, chunk in ipairs(vline) do
+    text = text .. chunk[1]
+  end
+  table.insert(lines, text)
+  local body = text:match("│ (.*)$")
+  if body then
+    max_text_width = math.max(max_text_width, vim.fn.strdisplaywidth(body))
+  end
+end
+local joined = table.concat(lines, "\n")
+
+check(joined:find("💬 L1%-2") ~= nil, "range header rendered for multi-line comment (L1-2)")
+check(joined:find("💬 L2") ~= nil, "header rendered for single-line comment (L2)")
+check(joined:find("│ Fix this", 1, true) ~= nil, "first line of multi-line comment rendered")
+check(joined:find("│ please", 1, true) ~= nil, "second line of multi-line comment rendered")
+check(joined:find("日本語", 1, true) ~= nil, "multibyte comment text rendered")
+
+local header_count = select(2, joined:gsub("┌─", ""))
+local footer_count = select(2, joined:gsub("└─", ""))
+check(header_count == 2 and footer_count == 2, "two stacked comment blocks rendered")
+
+check(joined:find("💬 L1%-2") < joined:find("💬 L2%f[%D]"), "blocks sorted by start_line")
+check(max_text_width <= 80, "wrapped text lines stay within max width (got " .. max_text_width .. ")")
+
+-- Japanese comment is wider than any window here, so it must have wrapped
+local body_line_count = select(2, joined:gsub("│ ", ""))
+check(body_line_count >= 4, "long multibyte comment wrapped onto multiple lines")
+
+-- Toggle off: no virt_lines should be produced
+require("reviewthem.config").setup({ inline_comments = false })
+split.refresh_decorations(session)
+local extmarks_off = vim.api.nvim_buf_get_extmarks(new_bufnr, renderer.get_namespace(), 0, -1, { details = true })
+local off_count = 0
+for _, m in ipairs(extmarks_off) do
+  if m[4].virt_lines then
+    off_count = off_count + 1
+  end
+end
+check(off_count == 0, "no virt_lines when inline_comments = false")
+
+-- Avoid the accidental-close guard firing on exit in this headless harness
+split.set_closing_intentionally()
+
+if failures > 0 then
+  print(failures .. " check(s) failed")
+  os.exit(1)
+end
+print("all checks passed")


### PR DESCRIPTION
## Summary
- Render each comment's full text inline below its anchor line in the split diff view using extmark `virt_lines`, as a bordered block (`┌─ 💬 L10-12 ─` header with the line range, `│`-prefixed text lines, `└─` footer)
- Anchor blocks at the comment's `end_line` on the matching side; multiple comments on the same line are stacked in `start_line` order
- Wrap long comment lines by display width (min(80, window width - 10)) with multibyte-safe character iteration, so Japanese comments wrap correctly instead of being truncated
- Add `inline_comments` config option (default: `true`); when disabled, behavior is exactly as before (only the eol `💬` sign)
- Add theme-friendly highlight groups `ReviewThemInlineComment` (links to `Comment`) and `ReviewThemInlineCommentBorder` (links to `NonText`)
- Keep the existing eol comment sign behavior; inline blocks refresh automatically on comment add/edit/delete via the existing decoration refresh path
- Add a headless functional test (`tests/inline_comments_spec.lua`) covering multi-line comments, multibyte wrapping, stacking, and the config toggle
- Document the feature in README and `:help reviewthem`

## Test plan
- [x] `nvim --headless -c "set rtp+=." -c "lua require('reviewthem').setup()" -c "q"` loads cleanly
- [x] `nvim --headless -l tests/inline_comments_spec.lua` passes (13 checks)
- [ ] Start a review session, add single-line and multi-line comments, and confirm inline blocks appear below the commented lines on the correct side
- [ ] Add two comments ending on the same line and confirm they stack in order
- [ ] Add a long Japanese comment and confirm it wraps readably
- [ ] Set `inline_comments = false` and confirm only the `💬` eol sign is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)