### PR TITLE
feat: add treesitter syntax highlighting and word-level diff to split view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project is inspired by [ReviewIt](https://github.com/yoshiko-pg/reviewit) -
 ## Features
 
 - **Split diff view** — Side-by-side old/new comparison with syntax highlighting
+- **Syntax highlighting** — Treesitter-based language highlighting in the diff view (works when a parser for the file's language is installed)
+- **Word-level diff** — The changed span within modified lines is highlighted on both sides
 - **File tree sidebar** — Browse changed files, track review progress
 - **Line-level comments** — Floating input window, supports multi-line ranges
 - **Session management** — Named sessions persisted as JSON, pause and resume anytime
@@ -142,6 +144,7 @@ require("reviewthem").setup({
   comment_sign = "💬",        -- sign shown on commented lines
   file_tree_width = 30,       -- sidebar width in columns
   auto_save = true,           -- auto-save session on changes
+  word_diff = true,           -- highlight changed spans within modified lines
   keymaps = {
     add_comment = "<leader>rc",
     confirm_comment = "<A-CR>",

--- a/doc/reviewthem.txt
+++ b/doc/reviewthem.txt
@@ -26,6 +26,9 @@ external plugin dependencies.
 
 Features:
 - Split diff view (side-by-side old/new comparison)
+- Treesitter-based syntax highlighting in the diff view (when a parser
+  for the file's language is installed)
+- Word-level diff highlighting of the changed span within modified lines
 - File tree sidebar with review progress
 - Line-level comments with floating input
 - Named sessions with JSON persistence
@@ -72,6 +75,7 @@ Call the setup function with optional configuration: >lua
       comment_sign = "💬",
       file_tree_width = 30,
       auto_save = true,
+      word_diff = true,
       keymaps = {
         add_comment = "<leader>rc",
         confirm_comment = "<A-CR>",
@@ -193,6 +197,12 @@ file_tree_width~
 auto_save~
     Default: true
     Automatically save the session after changes (debounced 500ms).
+
+word_diff~
+    Default: true
+    Highlight the changed span within modified line pairs (word-level
+    diff) using |hl-DiffText| via the `ReviewThemWordAdd` and
+    `ReviewThemWordDelete` highlight groups.
 
 keymaps~
     Table of keymap bindings. Set any key to `""` to disable it.

--- a/lua/reviewthem/config.lua
+++ b/lua/reviewthem/config.lua
@@ -4,6 +4,7 @@ M.defaults = {
   comment_sign = "💬",
   file_tree_width = 30,
   auto_save = true,
+  word_diff = true,
   keymaps = {
     add_comment = "<leader>rc",
     confirm_comment = "<A-CR>",

--- a/lua/reviewthem/diff/renderer.lua
+++ b/lua/reviewthem/diff/renderer.lua
@@ -8,6 +8,8 @@ M.setup_highlights = function()
     ReviewThemAdd = { default = true, link = "DiffAdd" },
     ReviewThemDelete = { default = true, link = "DiffDelete" },
     ReviewThemChange = { default = true, link = "DiffChange" },
+    ReviewThemWordAdd = { default = true, link = "DiffText" },
+    ReviewThemWordDelete = { default = true, link = "DiffText" },
     ReviewThemHunkHeader = { default = true, bg = "#3b3b4f", fg = "#a0a0c0", italic = true },
     ReviewThemFileHeader = { default = true, bg = "#2a4a2a", fg = "#c0e0c0", bold = true },
     ReviewThemLineNrOld = { default = true, fg = "#e06060" },
@@ -68,6 +70,20 @@ M.decorate_line = function(bufnr, line_idx, hunk_line)
     virt_text = { { nr_text .. " ", nr_hl_group } },
     virt_text_pos = "inline",
     priority = 10,
+  })
+end
+
+--- Highlight the differing span within a changed line (word-level diff).
+---@param bufnr number
+---@param line_idx number  0-indexed line in buffer
+---@param start_col number  0-indexed byte column, inclusive
+---@param end_col number  0-indexed byte column, exclusive
+---@param hl_group string
+M.add_word_diff = function(bufnr, line_idx, start_col, end_col, hl_group)
+  vim.api.nvim_buf_set_extmark(bufnr, ns, line_idx, start_col, {
+    end_col = end_col,
+    hl_group = hl_group,
+    priority = 110, -- above treesitter highlights (100)
   })
 end
 

--- a/lua/reviewthem/diff/split.lua
+++ b/lua/reviewthem/diff/split.lua
@@ -27,6 +27,54 @@ local view_state = {
   session = nil,
 }
 
+--- Check whether the byte at 1-indexed position `pos` is a UTF-8 continuation byte.
+---@param s string
+---@param pos number
+---@return boolean
+local function is_continuation_byte(s, pos)
+  local b = string.byte(s, pos)
+  return b ~= nil and b >= 0x80 and b < 0xC0
+end
+
+--- Compute the differing span between an old and a new line.
+--- Finds the common prefix and suffix byte-wise, backing off to UTF-8
+--- character boundaries, and returns the middle span for each side as
+--- 0-indexed byte columns {start_col, end_col} (end exclusive).
+---@param old_str string
+---@param new_str string
+---@return table|nil old_span, table|nil new_span
+local function compute_word_diff(old_str, new_str)
+  if old_str == new_str then
+    return nil, nil
+  end
+
+  local old_len = #old_str
+  local new_len = #new_str
+  local min_len = math.min(old_len, new_len)
+
+  -- Common prefix length (in bytes)
+  local prefix = 0
+  while prefix < min_len and old_str:byte(prefix + 1) == new_str:byte(prefix + 1) do
+    prefix = prefix + 1
+  end
+  -- Don't split a multibyte character: back off to a boundary
+  while prefix > 0 and is_continuation_byte(old_str, prefix + 1) do
+    prefix = prefix - 1
+  end
+
+  -- Common suffix length (in bytes), not overlapping the prefix
+  local suffix = 0
+  while suffix < min_len - prefix and old_str:byte(old_len - suffix) == new_str:byte(new_len - suffix) do
+    suffix = suffix + 1
+  end
+  -- The suffix must start at a character boundary
+  while suffix > 0 and is_continuation_byte(old_str, old_len - suffix + 1) do
+    suffix = suffix - 1
+  end
+
+  return { prefix, old_len - suffix }, { prefix, new_len - suffix }
+end
+
 --- Build aligned old/new content for a single file.
 ---@param file DiffFile
 ---@return string[] old_lines, string[] new_lines, table[] old_map, table[] new_map
@@ -56,8 +104,8 @@ local function build_split_content(file)
       local hline = hunk_lines[i]
 
       if hline.type == "context" then
-        table.insert(old_lines, " " .. hline.content)
-        table.insert(new_lines, " " .. hline.content)
+        table.insert(old_lines, hline.content)
+        table.insert(new_lines, hline.content)
         table.insert(old_map, {
           type = "diff_line",
           file = file.path,
@@ -89,14 +137,21 @@ local function build_split_content(file)
         -- Align removes and adds
         local max_len = math.max(#removes, #adds)
         for j = 1, max_len do
+          -- Word-level diff for positionally paired remove/add lines
+          local old_span, new_span
+          if j <= #removes and j <= #adds then
+            old_span, new_span = compute_word_diff(removes[j].content, adds[j].content)
+          end
+
           if j <= #removes then
-            table.insert(old_lines, "-" .. removes[j].content)
+            table.insert(old_lines, removes[j].content)
             table.insert(old_map, {
               type = "diff_line",
               file = file.path,
               side = "old",
               lineno = removes[j].old_lineno,
               hunk_line = removes[j],
+              word_diff = old_span,
             })
           else
             table.insert(old_lines, "")
@@ -104,13 +159,14 @@ local function build_split_content(file)
           end
 
           if j <= #adds then
-            table.insert(new_lines, "+" .. adds[j].content)
+            table.insert(new_lines, adds[j].content)
             table.insert(new_map, {
               type = "diff_line",
               file = file.path,
               side = "new",
               lineno = adds[j].new_lineno,
               hunk_line = adds[j],
+              word_diff = new_span,
             })
           else
             table.insert(new_lines, "")
@@ -148,6 +204,10 @@ local function apply_split_decorations(bufnr, line_map, session)
       renderer.decorate_hunk_header(bufnr, line_idx)
     elseif entry.type == "diff_line" then
       renderer.decorate_line(bufnr, line_idx, entry.hunk_line)
+      if config.word_diff and entry.word_diff and entry.word_diff[1] < entry.word_diff[2] then
+        local hl_group = entry.side == "old" and "ReviewThemWordDelete" or "ReviewThemWordAdd"
+        renderer.add_word_diff(bufnr, line_idx, entry.word_diff[1], entry.word_diff[2], hl_group)
+      end
       local key = entry.file .. ":" .. entry.side .. ":" .. entry.lineno
       if comment_lookup[key] then
         renderer.add_comment_sign(bufnr, line_idx, config.comment_sign)
@@ -158,6 +218,25 @@ local function apply_split_decorations(bufnr, line_map, session)
       })
     end
   end
+end
+
+--- Enable treesitter syntax highlighting for a diff buffer based on the file path.
+--- Falls back silently when no parser is available (zero-dependency plugin).
+---@param bufnr number
+---@param path string
+local function attach_treesitter(bufnr, path)
+  -- Stop any highlighter left over from a previously rendered file
+  pcall(vim.treesitter.stop, bufnr)
+
+  local ft = vim.filetype.match({ filename = path })
+  if not ft then
+    return
+  end
+  local ok, lang = pcall(vim.treesitter.language.get_lang, ft)
+  if not ok or not lang then
+    return
+  end
+  pcall(vim.treesitter.start, bufnr, lang)
 end
 
 --- Prevent accidental close of diff buffer windows.
@@ -239,6 +318,10 @@ M.render_file = function(session, file, old_winnr, new_winnr)
   vim.bo[new_bufnr].buftype = "nofile"
   vim.bo[new_bufnr].swapfile = false
   vim.bo[new_bufnr].filetype = "reviewthem-diff"
+
+  -- Language syntax highlighting (best effort, requires a treesitter parser)
+  attach_treesitter(old_bufnr, file.path)
+  attach_treesitter(new_bufnr, file.path)
 
   -- Protect from accidental close
   protect_diff_buffer(old_bufnr)


### PR DESCRIPTION
## Summary
- Strip the `+`/`-`/` ` prefix from rendered diff lines so the split buffers contain pure code — the add/remove state is already conveyed by the line highlights and the colored inline line numbers
- Enable treesitter-based language syntax highlighting in the diff panes: the language is detected from the file path (`vim.filetype.match` + `vim.treesitter.language.get_lang`) and the highlighter is attached with `pcall(vim.treesitter.start, ...)`, falling back silently to no highlighting when no parser is installed (keeps the plugin zero-dependency); the highlighter is stopped before re-rendering a different file to avoid stale parsers
- Add word-level (intra-line) diff highlighting: for each positionally paired remove/add line, the common prefix and suffix are scanned byte-wise (backing off to UTF-8 character boundaries) and the differing middle span is highlighted on both sides via new `ReviewThemWordAdd` / `ReviewThemWordDelete` groups (linked to `DiffText`, theme-friendly)
- Add a `word_diff = true` config option to disable word-level highlighting; documented in README and `:help reviewthem-configuration`

## Implementation notes
- Word diff spans are computed in `build_split_content()` and carried through the line map (`entry.word_diff = {start_col, end_col}`), then applied as `hl_group` extmarks with `end_col` in `apply_split_decorations()` (priority 110, above treesitter's 100)
- Pure adds/removes with no counterpart and identical pairs get no word diff mark
- Diff backgrounds still show through treesitter highlighting since `line_hl_group` only contributes the background
- No code relied on the old 1-column prefix offset (cursor context and keymaps are row-based), so stripping it required no other adjustments

## Test plan
- [x] Headless load check: `nvim --headless -c "set rtp+=." -c "lua require('reviewthem').setup()" -c "q"`
- [x] Headless functional check (scratch script via `nvim --headless -l`): fed a fake `DiffFile` through `render_file` and asserted prefix-free buffer lines, empty padding lines, expected word diff spans (including a `héllo`→`hállo` case verifying spans don't split multibyte chars), no span on unpaired removes, active treesitter highlighter on both buffers, working cursor context, and that `word_diff = false` removes the marks
- [ ] Open a review session on a Lua/TS file with a parser installed — verify code is syntax highlighted and changed spans within modified lines stand out
- [ ] Open a file with no parser installed — verify the diff renders normally with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)