### PR TITLE
feat: jump from a diff line to the real file with gf

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Commands are context-aware — session management commands are only available wh
 | `:ReviewThemDeleteComment` | Delete comment at cursor position |
 | `:ReviewThemShowComments` | List all comments (Enter=jump, d=delete) |
 | `:ReviewThemToggleReviewed` | Toggle reviewed status of current file |
+| `:ReviewThemOpenFile` | Open the file under the cursor in a new tab |
 | `:ReviewThemSubmit` | Export Markdown to clipboard and close |
 | `:ReviewThemPause` | Close UI, keep session saved |
 | `:ReviewThemAbort` | Discard session |
@@ -117,6 +118,9 @@ Default mappings in diff buffers (customizable in setup):
 | `<leader>rl` | Show all comments |
 | `<leader>re` | Focus file tree |
 | `<leader>rq` | Pause / close review |
+| `gf` | Open the file under the cursor in a new tab |
+
+`gf` (`:ReviewThemOpenFile`) opens the version shown on the side under the cursor: on the new side of a working-tree review it opens the actual file, otherwise it opens a readonly view of the file at the relevant git ref (press `q` there to return to the review).
 
 Comment input window:
 
@@ -151,6 +155,7 @@ require("reviewthem").setup({
     show_comments = "<leader>rl",
     focus_tree = "<leader>re",
     close_review = "<leader>rq",
+    open_file = "gf",
   },
 })
 ```

--- a/doc/reviewthem.txt
+++ b/doc/reviewthem.txt
@@ -81,6 +81,7 @@ Call the setup function with optional configuration: >lua
         show_comments = "<leader>rl",
         focus_tree = "<leader>re",
         close_review = "<leader>rq",
+        open_file = "gf",
       },
     })
 <
@@ -155,6 +156,13 @@ DURING AN ACTIVE REVIEW ~
 :ReviewThemTree
     Toggle the file tree sidebar.
 
+                                                         *:ReviewThemOpenFile*
+:ReviewThemOpenFile
+    Open the file under the cursor in a new tab, at the line under the
+    cursor. On the new side of a working-tree review this opens the
+    actual file; otherwise a readonly view of the file at the relevant
+    git ref is shown (press `q` there to return to the review).
+
 ==============================================================================
 6. MAPPINGS                                                 *reviewthem-mappings*
 
@@ -167,6 +175,7 @@ during a review session. All keys are configurable via |reviewthem-configuration
     <leader>rl      Show all comments
     <leader>re      Focus file tree
     <leader>rq      Pause / close review
+    gf              Open the file under the cursor in a new tab
 
 In the comment input floating window:
 

--- a/lua/reviewthem/commands.lua
+++ b/lua/reviewthem/commands.lua
@@ -35,6 +35,7 @@ local session_command_names = {
   "ReviewThemPause", "ReviewThemSubmit", "ReviewThemAbort",
   "ReviewThemAddComment", "ReviewThemEditComment", "ReviewThemDeleteComment",
   "ReviewThemShowComments", "ReviewThemToggleReviewed", "ReviewThemTree",
+  "ReviewThemOpenFile",
 }
 
 --- Delete a list of user commands (ignoring errors for missing ones).
@@ -450,6 +451,13 @@ register_session_commands = function()
     )
   end, {
     desc = "Toggle reviewed status for the current file",
+  })
+
+  -- :ReviewThemOpenFile
+  vim.api.nvim_create_user_command("ReviewThemOpenFile", function()
+    require("reviewthem.openfile").open_at_cursor()
+  end, {
+    desc = "Open the file under the cursor in a new tab",
   })
 
   -- :ReviewThemTree

--- a/lua/reviewthem/config.lua
+++ b/lua/reviewthem/config.lua
@@ -13,6 +13,7 @@ M.defaults = {
     show_comments = "<leader>rl",
     focus_tree = "<leader>re",
     close_review = "<leader>rq",
+    open_file = "gf",
   },
 }
 

--- a/lua/reviewthem/keymaps.lua
+++ b/lua/reviewthem/keymaps.lua
@@ -45,6 +45,9 @@ M.setup_diff_keymaps = function()
         end
       end, "Focus file tree")
       map("n", km.close_review, "<cmd>ReviewThemPause<CR>", "Close/pause review")
+
+      -- Open real file
+      map("n", km.open_file, "<cmd>ReviewThemOpenFile<CR>", "Open file at cursor line")
     end,
   })
 end

--- a/lua/reviewthem/openfile.lua
+++ b/lua/reviewthem/openfile.lua
@@ -1,0 +1,126 @@
+local M = {}
+
+--- Clamp a line number to the buffer's line count and move the cursor there.
+---@param winnr number
+---@param lineno number
+local function set_cursor_clamped(winnr, lineno)
+  local bufnr = vim.api.nvim_win_get_buf(winnr)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local target = math.max(1, math.min(lineno or 1, line_count))
+  vim.api.nvim_win_set_cursor(winnr, { target, 0 })
+end
+
+--- Open the working-tree version of a file in a new tab.
+---@param file_path string  Path relative to the git root
+---@param lineno number
+---@return boolean ok
+local function open_working_tree_file(file_path, lineno)
+  local git = require("reviewthem.git")
+  local git_root = git.get_git_root()
+  if not git_root then
+    vim.notify("reviewthem.nvim: Not in a git repository.", vim.log.levels.ERROR)
+    return false
+  end
+
+  local full_path = git_root .. "/" .. file_path
+  if vim.fn.filereadable(full_path) == 0 then
+    vim.notify(
+      string.format("reviewthem.nvim: '%s' does not exist in the working tree.", file_path),
+      vim.log.levels.WARN
+    )
+    return false
+  end
+
+  vim.cmd("tabedit " .. vim.fn.fnameescape(full_path))
+  set_cursor_clamped(0, lineno)
+  return true
+end
+
+--- Open the version of a file at a git ref in a readonly scratch buffer in a new tab.
+---@param ref string
+---@param file_path string  Path relative to the git root
+---@param lineno number
+---@return boolean ok
+local function open_ref_file(ref, file_path, lineno)
+  local git = require("reviewthem.git")
+  local lines = git.get_file_content(ref, file_path)
+  if not lines then
+    vim.notify(
+      string.format("reviewthem.nvim: '%s' does not exist at '%s'.", file_path, ref),
+      vim.log.levels.WARN
+    )
+    return false
+  end
+
+  local bufname = string.format("reviewthem://%s:%s", ref, file_path)
+  local bufnr = vim.fn.bufnr(bufname)
+  if bufnr == -1 or not vim.api.nvim_buf_is_valid(bufnr) then
+    bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, bufname)
+  end
+
+  vim.bo[bufnr].modifiable = true
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = false
+  vim.bo[bufnr].buftype = "nofile"
+  vim.bo[bufnr].swapfile = false
+
+  local filetype = vim.filetype.match({ filename = file_path })
+  if filetype then
+    vim.bo[bufnr].filetype = filetype
+  end
+
+  -- Open in a new tab so the review layout stays untouched
+  vim.cmd("tabnew")
+  local placeholder = vim.api.nvim_get_current_buf()
+  vim.api.nvim_win_set_buf(0, bufnr)
+  if placeholder ~= bufnr and vim.api.nvim_buf_is_valid(placeholder)
+    and vim.api.nvim_buf_get_name(placeholder) == "" and not vim.bo[placeholder].modified then
+    pcall(vim.api.nvim_buf_delete, placeholder, { force = true })
+  end
+
+  set_cursor_clamped(0, lineno)
+
+  -- q closes the tab and returns to the review tab
+  vim.keymap.set("n", "q", function()
+    if #vim.api.nvim_list_tabpages() > 1 then
+      vim.cmd("tabclose")
+    end
+  end, { buffer = bufnr, nowait = true, silent = true, desc = "Close file view" })
+
+  return true
+end
+
+--- Open the real file for the diff line under the cursor in a new tab.
+--- Working-tree reviews open the actual file; ref-based sides open a
+--- readonly scratch buffer with the content at the relevant ref.
+M.open_at_cursor = function()
+  local ui = require("reviewthem.ui")
+  local context = ui.get_cursor_context()
+  if not context then
+    vim.notify("Place cursor on a diff line to open the file.", vim.log.levels.WARN)
+    return
+  end
+
+  local state = require("reviewthem.session.state")
+  local session = state.get_active()
+  if not session then
+    vim.notify("reviewthem.nvim: No active review session.", vim.log.levels.WARN)
+    return
+  end
+
+  if context.side == "new" and (session.compare_ref == nil or session.compare_ref == "") then
+    -- Working-tree review: open the actual file
+    open_working_tree_file(context.file, context.lineno)
+  else
+    local ref
+    if context.side == "new" then
+      ref = session.compare_ref
+    else
+      ref = session.base_ref or "HEAD"
+    end
+    open_ref_file(ref, context.file, context.lineno)
+  end
+end
+
+return M


### PR DESCRIPTION
## Summary
- Add `:ReviewThemOpenFile` (session-mode only) with a default `gf` keymap in diff buffers (configurable via `keymaps.open_file`) to jump from a diff line to the real file
- The file always opens in a **new tab**, so the protected three-pane review layout stays untouched
- On the new side of a working-tree review, the actual file is opened at the cursor line (resolved against the git root)
- On the old side, or the new side with a compare ref, a readonly scratch buffer named `reviewthem://<ref>:<path>` is opened with the content from `git show`, filetype detection via `vim.filetype.match`, and `q` mapped to close the tab and return to the review (real working-tree files keep `q` untouched)
- Missing files (e.g. deleted at a ref, or a deleted file in the working tree) notify instead of erroring, and the target line is clamped to the file's line count
- Document the command, mapping, and config key in README and `doc/reviewthem.txt`

## Test plan
- [x] Headless load check: `nvim --headless -c "set rtp+=." -c "lua require('reviewthem').setup()" -c "q"`
- [x] Headless end-to-end smoke test in a throwaway git repo (26 assertions): working-tree open lands on the correct line with matching content, ref-based open creates the readonly `reviewthem://HEAD:<path>` scratch buffer with correct filetype/cursor/content, `q` closes the tab and returns to the review, deleted files and non-diff lines are safe no-ops
- [ ] Manual: `gf` on a diff line during a review opens the file in a new tab without disturbing the review layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
